### PR TITLE
CDMA: Unknown is displayed for incoming call

### DIFF
--- a/src/com/android/services/telephony/TelephonyConnection.java
+++ b/src/com/android/services/telephony/TelephonyConnection.java
@@ -636,7 +636,7 @@ abstract class TelephonyConnection extends Connection {
         if (mOriginalConnection != null) {
             if (((getAddress() != null) &&
                     (getPhone().getPhoneType() == TelephonyManager.PHONE_TYPE_CDMA)) &&
-                    !isValidRingingCall()) {
+                    !mOriginalConnection.isIncoming()) {
                 address = getAddressFromNumber(mOriginalConnection.getOrigDialString());
             } else {
                 address = getAddressFromNumber(mOriginalConnection.getAddress());


### PR DESCRIPTION
In CDMA. After answering and disconnecting a MT call, Unknown is dispayed
in call logs. Issue is due to calling updateAddress() function on
disconnecting the call and it is fixed by checking whether call is
incoming or outgoing call, so that address is obtained from getAddress().

CRs-Fixed: 942673

Change-Id: Icb0c72ad3b21c8ff944155932cacf5710bf0a5b4
