### PR TITLE
Telephony: Fix NPE when any of the sim is disabled

### DIFF
--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -838,7 +838,7 @@ public class MobileNetworkSettings extends PreferenceActivity
                 == TelephonyManager.MultiSimVariants.DSDS;
         boolean isMultiRat = SystemProperties.getBoolean("ro.ril.multi_rat_capable", false);
         if (isDsds && !isMultiRat && (mPhone.getSubId()
-                != mSubscriptionManager.getDefaultDataSubscriptionInfo().getSubscriptionId())) {
+                != mSubscriptionManager.getDefaultDataSubId())) {
             root.removePreference(mButtonPreferredNetworkMode);
             root.removePreference(mLteDataServicePref);
             root.removePreference(mButtonEnabledNetworks);


### PR DESCRIPTION
After enabling airplane mode, clicking on Cellular networks
generates a crash.

Change-Id: I7261a8ed5b97487bc9b5b2026a9c82ed122eaa0a
Signed-off-by: Umair Khan omerjerk@gmail.com
