### PR TITLE
networksettings: Don't crash when the sim is ejected

### DIFF
--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -275,7 +275,9 @@ public class MobileNetworkSettings extends PreferenceActivity
             }
 
             List<SubscriptionInfo> infos = new ArrayList<SubscriptionInfo>();
-            infos.add(sir);
+            if (sir != null) {
+                infos.add(sir);
+            }
             return infos;
         }
         return mSubscriptionManager.getActiveSubscriptionInfoList();
@@ -289,7 +291,9 @@ public class MobileNetworkSettings extends PreferenceActivity
             List<SubscriptionInfo> newSil = determineSubscriptionsToUse();
             if (DBG) log("onSubscriptionsChanged: newSil: " + newSil +
                     " mActiveSubInfos: " + mActiveSubInfos);
-            if (newSil == null) {
+            if (newSil == null || newSil.isEmpty()) {
+                if (DBG) log("onSubscriptionsChanged: empty subscriptions, finishing");
+                finish();
                 return;
             }
             // Update UI when there is a change in number of active subscriptions or


### PR DESCRIPTION
If the current subscription ceases to exist, for instance, after
the SIM card is ejected, this preference screen would crash
when setting up the view.

This patch contains two parts, the first doesn't add non-existing
(null) subscriptions to the valid subscription list, the second
finishes the screen when the list of subscriptions is empty because
the screen is effectively useless.

Ticket: CYNGNOS-1794
Change-Id: Iedd349dc3757c62ad74e47927fc77109ea4ba8e6
