### PR TITLE
Port network mode toggle from CM12

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -651,6 +651,13 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name=".PhoneToggler" android:permission="com.android.phone.CHANGE_NETWORK_MODE">
+            <intent-filter>
+                <action android:name="com.android.internal.telephony.REQUEST_NETWORK_MODE" />
+                <action android:name="com.android.internal.telephony.MODIFY_NETWORK_MODE" />
+            </intent-filter>
+        </receiver>
+
         <!-- service to dump telephony information -->
         <service android:name="HfaService" android:exported="false"/>
 
@@ -723,4 +730,9 @@
           </intent-filter>
        </receiver>
     </application>
+
+    <permission android:name="com.android.phone.CHANGE_NETWORK_MODE"
+        android:label="@string/perm_change_mobile_network"
+        android:description="@string/perm_change_mobile_network_desc"
+        android:protectionLevel="signature|privileged" />
 </manifest>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -221,4 +221,8 @@
     <string name="exportAllcontatsNoContacts">No contacts found to export to SIM</string>
 
     <string name="msim_mobile_network_settings_title">SIM %d cellular network settings</string>
+
+    <!-- Permission to modify network mode via intent -->
+    <string name="perm_change_mobile_network">Change network mode</string>
+    <string name="perm_change_mobile_network_desc">Allows an application to modify the current network mode.</string>
 </resources>

--- a/src/com/android/phone/PhoneToggler.java
+++ b/src/com/android/phone/PhoneToggler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2010 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.phone;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.AsyncResult;
+import android.os.Handler;
+import android.os.Message;
+import android.provider.Settings;
+import android.telephony.SubscriptionManager;
+import android.util.Log;
+
+import com.android.internal.telephony.Phone;
+import com.android.internal.telephony.PhoneConstants;
+import com.android.internal.telephony.PhoneFactory;
+
+public class PhoneToggler extends BroadcastReceiver  {
+
+    @Deprecated
+    public static final String ACTION_REQUEST_NETWORK_MODE =
+            "com.android.internal.telephony.REQUEST_NETWORK_MODE";
+
+    public static final String ACTION_MODIFY_NETWORK_MODE =
+            "com.android.internal.telephony.MODIFY_NETWORK_MODE";
+
+    public static final String EXTRA_NETWORK_MODE = "networkMode";
+
+    public static final String CHANGE_NETWORK_MODE_PERM =
+            "com.android.phone.CHANGE_NETWORK_MODE";
+
+    private static final String LOG_TAG = "PhoneToggler";
+    private static final boolean DBG = false;
+
+    private Phone getPhone() {
+        return PhoneFactory.getPhone(SubscriptionManager.getPhoneId(
+                SubscriptionManager.getDefaultDataSubId()));
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (ACTION_MODIFY_NETWORK_MODE.equals(action)) {
+            if (DBG) Log.d(LOG_TAG, "Got modify intent");
+            if (intent.getExtras() != null) {
+                int networkMode = intent.getExtras().getInt(EXTRA_NETWORK_MODE);
+                boolean networkModeOk = false;
+                Phone phone = getPhone();
+                int phoneType = phone.getPhoneType();
+                boolean isLteOnCdma = phone.getLteOnCdmaMode() == PhoneConstants.LTE_ON_CDMA_TRUE;
+
+                if (phoneType == PhoneConstants.PHONE_TYPE_GSM) {
+                    if (networkMode == Phone.NT_MODE_GSM_ONLY
+                            || networkMode == Phone.NT_MODE_GSM_UMTS
+                            || networkMode == Phone.NT_MODE_WCDMA_PREF
+                            || networkMode == Phone.NT_MODE_LTE_GSM_WCDMA
+                            || networkMode == Phone.NT_MODE_WCDMA_ONLY) {
+                        networkModeOk = true;
+                    }
+                } else if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {
+                    if (networkMode == Phone.NT_MODE_CDMA
+                            || networkMode == Phone.NT_MODE_CDMA_NO_EVDO
+                            || networkMode == Phone.NT_MODE_EVDO_NO_CDMA) {
+                        networkModeOk = true;
+                    }
+                }
+                if (context.getResources().getBoolean(R.bool.world_phone) || isLteOnCdma) {
+                    if (networkMode == Phone.NT_MODE_GLOBAL) {
+                        networkModeOk = true;
+                    }
+                }
+
+                if (networkModeOk) {
+                    if (DBG) Log.d(LOG_TAG, "Changing network mode to " + networkMode);
+                    changeNetworkMode(networkMode);
+                } else {
+                    Log.e(LOG_TAG,"Invalid network mode: "+networkMode);
+                }
+            }
+        } else if (ACTION_REQUEST_NETWORK_MODE.equals(action)) {
+            if (DBG) Log.e(LOG_TAG,"Requested network mode. Not honoring request. Get your own info.");
+        } else {
+            if (DBG) Log.d(LOG_TAG,"Unexpected intent: " + intent);
+        }
+    }
+
+    private void changeNetworkMode(int modemNetworkMode) {
+        getPhone().setPreferredNetworkType(modemNetworkMode, null);
+    }
+
+}


### PR DESCRIPTION
This brings back the phone toggler for cm13. This is now restricted to
system apps.

Also includes:
    PhoneToggler: use current phone with data to toggle network modes

```
Ref: CYNGNOS-1207

Change-Id: I1db2b49a85f0c6a362308dcf5583445ce9416fc3
Signed-off-by: Roman Birg <roman@cyngn.com>
```

Ref: CYNGNOS-1824

Change-Id: Ibb8f33db71224b4559dcbf377c5844edc88548a7
