### PR TITLE
Phone: Sprint MWI Quirk: Phantom message wait indicator workaround

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -28,6 +28,10 @@
     <string name="blacklist_summary_disabled">Disabled</string>
     <string name="blacklist_summary">You will not receive incoming calls or messages from phone numbers on the blocked caller list</string>
 
+    <!-- Sprint MWI Quirk: Phantom message wait indicator workaround -->
+    <string name="mwi_notification_title">Message wait indicator</string>
+    <string name="mwi_notification_summary">Show message wait indicator voicemail notifications</string>
+
     <!-- My Phone Number -->
     <string name="phone_number_label">My phone number</string>
     <string name="phone_number_summary">Set the phone number for this device</string>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -147,6 +147,13 @@
     <!-- DEPRECATED: Use CarrierConfigManager#KEY_SHOW_CDMA_CHOICES_BOOL -->
     <bool name="config_show_cdma" translatable="false">false</bool>
 
+    <!-- Sprint Message Wait Indicator Quirk
+         If true, message wait indicators are hidden by default on this device
+         unless the user enables it in Call Settings.  This quirk is necessary
+         for the "Phantom Voicemail" issue where notifications are impossible
+         to dismiss on the Sprint network. -->
+    <bool name="sprint_mwi_quirk">false</bool>
+
     <!-- Package name for the default in-call UI and dialer [DO NOT TRANSLATE] -->
     <string name="ui_default_package" translatable="false">com.android.dialer</string>
 

--- a/res/xml/voicemail_settings.xml
+++ b/res/xml/voicemail_settings.xml
@@ -60,6 +60,13 @@
         android:key="@string/voicemail_notification_vibrate_key"
         android:title="@string/voicemail_notification_vibrate_when_title"
         android:persistent="true" />
+
+    <SwitchPreference
+          android:key="button_mwi_notification_key"
+          android:title="@string/mwi_notification_title"
+          android:summary="@string/mwi_notification_summary"
+          android:defaultValue="false"/>
+
     <SwitchPreference
         android:key="@string/voicemail_visual_voicemail_key"
         android:title="@string/voicemail_visual_voicemail_switch_title" />"

--- a/src/com/android/phone/NotificationMgr.java
+++ b/src/com/android/phone/NotificationMgr.java
@@ -355,6 +355,17 @@ public class NotificationMgr {
             }
         }
 
+        boolean notifProp = mApp.getResources().getBoolean(R.bool.sprint_mwi_quirk);
+        boolean notifOption = CMSettings.System.getInt(mApp.getContentResolver(),
+                CMSettings.System.ENABLE_MWI_NOTIFICATION, 0) == 1;
+        if (notifProp && !notifOption) {
+            // sprint_mwi_quirk is true, and ENABLE_MWI_NOTIFICATION is unchecked or unset (false)
+            // hide the mwi, but log if we're debugging.
+            visible = false;
+            if (DBG) log("updateMwi(): mwi_notification is disabled. Ignoring...");
+            return;
+        }
+
         Log.i(LOG_TAG, "updateMwi(): subId " + subId + " update to " + visible);
         mMwiVisible.put(subId, visible);
 

--- a/src/com/android/phone/settings/VoicemailSettingsActivity.java
+++ b/src/com/android/phone/settings/VoicemailSettingsActivity.java
@@ -104,6 +104,8 @@ public class VoicemailSettingsActivity extends PreferenceActivity
     private static final String BUTTON_VOICEMAIL_KEY = "button_voicemail_key";
     private static final String BUTTON_VOICEMAIL_PROVIDER_KEY = "button_voicemail_provider_key";
     private static final String BUTTON_VOICEMAIL_SETTING_KEY = "button_voicemail_setting_key";
+    private static final String BUTTON_VOICEMAIL_CATEGORY_KEY = "button_voicemail_category_key";
+    private static final String BUTTON_MWI_NOTIFICATION_KEY = "button_mwi_notification_key";
 
     /** Event for Async voicemail change call */
     private static final int EVENT_VOICEMAIL_CHANGED        = 500;


### PR DESCRIPTION
If true, message wait indicators are hidden by default on this device
unless the user enables it in Call Settings. This quirk is necessary
for the "Phantom Voicemail" issue where notifications that are
impossible to dismiss on the Sprint network. In rare instances, feature
phone voicemail gets stuck in a Sprint account where smart phones are
unable to delete them. Sprint will not help the subscriber fix this,
as their own Android phones ignore message wait indicators.

Enable 'sprint_mwi_quirk' in overlay/packages/services/Telephony/res/values/config.xml
for this option to appear in the Phone app.

Phone > Settings > Calls > Voicemail > Message wait indicator

Default is disabled, as Sprint Android phones have no reason to see
message wait indicators. It can however be enabled for Sprint phones
used on overseas carriers where message wait indicators are desired.

Rebased on M

Additional changes already merged
https://github.com/CyanogenMod/cm_platform_sdk/blob/cm-13.0/src/java/cyanogenmod/providers/CMSettings.java#L1166

Change-Id: I915c81b70b681b154e931d59b584cf48ff0105c7
